### PR TITLE
DNS during enable script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Run the following commands on an all-snap image:
     $ sudo snap install --beta --devmode classic
     $ sudo classic
     ...
+    (classic)ubuntu@localhost:~$ sudo apt update
     (classic)ubuntu@localhost:~$ exit
     $
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Run the following commands on an all-snap image:
 
     $ sudo snap install --beta --devmode classic
     $ sudo classic
-    (classic)ubuntu@localhost:~$ sudo apt update
     ...
     (classic)ubuntu@localhost:~$ exit
+    $
 
 The environment is very lightweight and full hardware and network
 access is possible.

--- a/bin/create
+++ b/bin/create
@@ -31,8 +31,12 @@ SNAPROOT="/var/lib/snapd/snaps/${CORE}_${VERSION}.snap"
 /usr/bin/unsquashfs -d $ROOT $SNAPROOT
 mkdir $ROOT/snappy
 
-# enable
+# call the enable.sh script and make sure we have
+# DNS resolution available (needed by apt update)
+mkdir -p $ROOT/run/resolvconf
+cp /run/resolvconf/resolv.conf $ROOT/run/resolvconf/
 sudo chroot $ROOT /var/lib/classic/enable.sh
+rm -rf $ROOT/run/resolvconf
 
 # copy important config
 for f in hostname timezone localtime; do


### PR DESCRIPTION
- make sure we have working DNS resolution when the enable.sh script runs, it calls "apt update" now and needs working network access
- also drop "sudo apt update" from the README.md this happens automatically now