### PR TITLE
create: create /etc/alternatives in classic env

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -46,6 +46,8 @@ for f in hosts; do
     cp -a /etc/$f $ROOT/etc/
 done
 
+# create /etc/alternatives for now
+mkdir -p $ROOT/etc/alternatives
 
 # don't start services in the chroot on apt-get install
 cat <<EOF > "$ROOT/usr/sbin/policy-rc.d"


### PR DESCRIPTION
The latest core does not have /etc/alternatives anymore. This
will break debs that assume this dir is there.

This PR is a hotfix. The real fix is to tar /etc/alternatives in
core and restore it but that needs a change in core as well.