### PR TITLE
create: support core18

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -15,11 +15,16 @@ if [ $(id -u) -ne 0 ]; then
 fi
 
 CORE=""
-if [ -e /snap/core/current ]; then
+if grep -q "Ubuntu Core 18" /etc/os-release; then
+    CORE="core18"
+elif grep -q "Ubuntu Core 16" /etc/os-release; then
     CORE="core"
-elif [ -e /snap/ubuntu-core/current ]; then
-    CORE="ubuntu-core"
 else
+    echo "Classic mode only works on Ubuntu Core"
+    exit 1
+fi
+
+if [ ! -e /snap/${CORE}/current ]; then
     echo "Cannot find core snap"
     exit 1
 fi


### PR DESCRIPTION
This is a bit of a RFC - if https://github.com/snapcore/core18/pull/84 lands we can land this one to get classic support on core18. Or we rethink the approach a bit because with the lack of /etc/alternatives we have a slightly different classic now anyway.

See also https://forum.snapcraft.io/t/classic-dimension-for-core18/7985