### PR TITLE
port classic to UC18 and put into "18" branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ background binaries will exit when the classic dimension is closed.
 
 We also plan to have a generic `snap shell` feature, once that lands
 `sudo classic` will be replaced with `snap shell classic`.
+
+## Auto Builds
+
+This branch is automatically mirrored into the https://launchpad.net/classic-snap project to the https://code.launchpad.net/~snappy-dev/classic-snap/+git/classic-snap/+ref/master tree.
+
+Automatic snap builds and uploads to the edge channel happen for every commit in the master branch at https://code.launchpad.net/~snappy-dev/+snap/classic 
+
+If you made a commit, please test the resulting snap package from edge and make sure it gets promoted to the beta channel after a successful test run.

--- a/bin/create
+++ b/bin/create
@@ -4,8 +4,7 @@ set -eu
 
 ROOT=$SNAP_COMMON/classic
 
-# check for the last bit that got created
-if [ -x $ROOT/usr/sbin/policy-rc.d ]; then
+if [ -d $ROOT ]; then
     echo "classic already enabled"
     exit 1
 fi
@@ -16,15 +15,15 @@ if [ $(id -u) -ne 0 ]; then
 fi
 
 # FIXME: We really should ensure this also works on
-#        classic, its an easy way to get a chroot there
-if ! grep -q "Ubuntu Core" /etc/os-release; then
+#        classic, it is an easy way to get a chroot there
+if ! grep -q "ID=ubuntu-core" /etc/os-release; then
     echo "Classic mode only works on Ubuntu Core"
     exit 1
 fi
 
 echo "Creating classic environment"
 mkdir -p $ROOT
-tar -x -f $SNAP/bionic-base-*.tar.gz -C $ROOT
+tar -x -f $SNAP/bionic-base.tar.gz -C $ROOT
 mkdir -p $ROOT/snappy
 
 # DNS resolution available (needed by apt update)

--- a/bin/create
+++ b/bin/create
@@ -4,7 +4,8 @@ set -eu
 
 ROOT=$SNAP_COMMON/classic
 
-if [ -d $ROOT ]; then
+# check for the last bit that got created
+if [ -x $ROOT/usr/sbin/policy-rc.d ]; then
     echo "classic already enabled"
     exit 1
 fi
@@ -14,36 +15,36 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
-CORE=""
-if [ -e /snap/core/current ]; then
-    CORE="core"
-elif [ -e /snap/ubuntu-core/current ]; then
-    CORE="ubuntu-core"
-else
-    echo "Cannot find core snap"
+# FIXME: We really should ensure this also works on
+#        classic, its an easy way to get a chroot there
+if ! grep -q "Ubuntu Core" /etc/os-release; then
+    echo "Classic mode only works on Ubuntu Core"
     exit 1
 fi
 
-# FIXME: confinement will prevent this
 echo "Creating classic environment"
-VERSION="$(/bin/readlink /snap/${CORE}/current)"
-SNAPROOT="/var/lib/snapd/snaps/${CORE}_${VERSION}.snap"
-/usr/bin/unsquashfs -d $ROOT $SNAPROOT
-mkdir $ROOT/snappy
+mkdir -p $ROOT
+tar -x -f $SNAP/bionic-base-*.tar.gz -C $ROOT
+mkdir -p $ROOT/snappy
 
-# call the enable.sh script and make sure we have
 # DNS resolution available (needed by apt update)
-mkdir -p $ROOT/run/resolvconf
-cp /run/resolvconf/resolv.conf $ROOT/run/resolvconf/
-sudo chroot $ROOT /var/lib/classic/enable.sh
-rm -rf $ROOT/run/resolvconf
+cp /etc/resolv.conf $ROOT/etc/
+cat > $ROOT/etc/apt/apt.conf.d/00-no-pr-set-new-privs.conf <<EOF
+// "snap run" will apply a seccomp sandbox in "complain" mode.
+// Then apt will call "prctl(PR_SET_NO_NEW_PRIVS)" in the methods
+// which will result in execve() for apt-key to fail. Workaround
+// by disabling the sandbox in apt.
+Debug::NoDropPrivs "1";
+EOF
+chroot $ROOT apt install -y sudo libnss-extrausers vim.tiny
+
 
 # copy important config
 for f in hostname timezone localtime; do
-    cp -a /etc/writable/$f $ROOT/etc/writable
+    cp -a /etc/writable/$f $ROOT/etc
 done
-for f in hosts; do
-    cp -a /etc/$f $ROOT/etc/
+for f in resolv.conf nsswitch.conf hosts; do
+    cp -a /etc/$f $ROOT/etc
 done
 
 

--- a/bin/reset
+++ b/bin/reset
@@ -9,7 +9,7 @@ if [ "$(id -u)" != "0" ]; then
     exit 1
 fi
 
-for d in /home /run /proc /sys /dev /var/lib/extrausers /etc/sudoers /etc/sudoers.d /snappy; do
+for d in /home /run /proc /sys /dev/pts /dev /var/lib/extrausers /etc/sudoers /etc/sudoers.d /snappy; do
   if mountpoint -q "$ROOT/$d"; then
     umount "$ROOT/$d"
   fi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,8 @@ confinement: devmode
 grade: devel
 base: core18
 
+# All apps are created without a wrapper script (adapter: none) because
+# they are just simple shell scripts, no need for wrappers.
 apps:
   create:
     command: bin/create
@@ -30,5 +32,6 @@ parts:
     plugin: nil
     override-build: |
       wget -P $SNAPCRAFT_PART_INSTALL http://cdimage.ubuntu.com/ubuntu-base/bionic/daily/current/bionic-base-$(dpkg --print-architecture).tar.gz
+      (cd $SNAPCRAFT_PART_INSTALL && ln -s bionic-base-$(dpkg --print-architecture).tar.gz bionic-base.tar.gz)
     stage:
-      - ./bionic-base-*.tar.gz
+      - ./bionic-base*.tar.gz

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,24 +1,35 @@
 name: classic
-summary: A classic shell environment for Ubuntu Core all-snap installations
-description: This snap provides a full classic shell environment including dpkg and apt support.
-version: 16.04
+summary: A classic shell environment for Ubuntu Core installations
+description: |
+  This snap provides a full classic shell environment including dpkg and
+  apt support.
+version: 18.04-0.1
 confinement: devmode
 architectures: [ all ]
 grade: devel
-assumes: [snapd2.23]
+base: core18
 
 apps:
   create:
     command: bin/create
     plugs: [classic-support]
+    adapter: none
   reset:
     command: bin/reset
     plugs: [classic-support]
+    adapter: none
   classic:
     command: bin/classic
     plugs: [classic-support]
+    adapter: none
 
 parts:
   copy:
     plugin: dump
     source: .
+  base:
+    plugin: nil
+    override-build: |
+      wget -P $SNAPCRAFT_PART_INSTALL http://cdimage.ubuntu.com/ubuntu-base/bionic/daily/current/bionic-base-$(dpkg --print-architecture).tar.gz
+    stage:
+      - ./bionic-base-*.tar.gz


### PR DESCRIPTION
This makes the classic dimension for UC18 available via the classic
snap. It will be provided in the "18" track for the classic snap. In
addition the "classic" snap in "latest" (which defaults to xenial)
will print a message when it is run on a core that does not match.

The approach is slightly different than what was done in UC16,
i.e. the base tarfile from ubuntu 18.04 is included in the snap
and that is used to prepare the chroot environment (see also
https://forum.snapcraft.io/t/7985 for a discussion about this).

Note that as part of the process the sandboxing of apt has to be
disabled currently.