### PR TITLE
create: improve user information

### DIFF
--- a/bin/classic
+++ b/bin/classic
@@ -42,6 +42,7 @@ do_bindmount /proc /proc
 do_bindmount /sys /sys
 do_bindmount /dev /dev
 do_bindmount / /snappy
+do_bindmount /etc/sudoers  $ROOT/etc/sudoers
 
 if [ -z "$SUDO_USER" ]; then
     echo "Cannot determine calling user, logging into classic as root"

--- a/bin/classic
+++ b/bin/classic
@@ -42,7 +42,6 @@ do_bindmount /proc /proc
 do_bindmount /sys /sys
 do_bindmount /dev /dev
 do_bindmount / /snappy
-do_bindmount /etc/sudoers  $ROOT/etc/sudoers
 
 if [ -z "$SUDO_USER" ]; then
     echo "Cannot determine calling user, logging into classic as root"
@@ -52,6 +51,12 @@ fi
 # fix LP: #1619455
 cp -a /var/lib/extrausers/* $ROOT/var/lib/extrausers/
 cp -a /etc/sudoers.d/* $ROOT/etc/sudoers.d/
+# this is only needed when this is run on classic
+if ! grep -q ^${SUDO_USER} $ROOT/var/lib/extrausers/passwd && ! grep -q ^${SUDO_USER} $ROOT/etc/passwd; then
+    grep ^${SUDO_USER} /etc/passwd >> $ROOT/etc/passwd
+    grep ^${SUDO_USER} /etc/shadow >> $ROOT/etc/shadow
+    echo "${SUDO_USER} ALL=(ALL) NOPASSWD:ALL" > $ROOT/etc/sudoers.d/${SUDO_USER}
+fi
 
 # assemble command line
 DEVPTS="mount -o mode=666,ptmxmode=666 -t devpts devpts /dev/pts"

--- a/bin/create
+++ b/bin/create
@@ -14,11 +14,6 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
-if ! grep -q 'ID=ubuntu-core' /etc/os-release; then
-    echo "Classic mode only works on Ubuntu Core"
-    exit 1
-fi
-
 CORE=""
 if [ -e /snap/core/current ]; then
     CORE="core"
@@ -54,15 +49,8 @@ sudo chroot $ROOT /var/lib/classic/enable.sh
 mv $ROOT/etc/resolv.conf.save $ROOT/etc/resolv.conf
 
 # copy important config
-for f in hostname timezone localtime; do
-    if [ -e /etc/writable/$f ]; then
-        cp -a /etc/writable/$f $ROOT/etc/writable
-    elif [ -e /etc/$f ]; then
-        cp -a /etc/$f $ROOT/writable/etc
-    fi
-done
-for f in hosts; do
-    cp -a /etc/$f $ROOT/etc/
+for f in hostname timezone localtime hosts resolv.conf; do
+    cp -aL --remove-destination /etc/$f $ROOT/etc
 done
 
 # create /etc/alternatives for now
@@ -86,7 +74,7 @@ chmod 755 "$ROOT/usr/sbin/policy-rc.d"
 chmod 1777 "$ROOT/tmp"
 
 # tell the user if classic does not match the ubuntu core release
-if ! grep -q 'VERSION_ID=\"16\"' /var/lib/snapd/hostfs/etc/os-release; then
+if grep -q "ID=ubuntu-core" /var/lib/snapd/hostfs/etc/os-release && ! grep -q 'VERSION_ID=\"16\"' /var/lib/snapd/hostfs/etc/os-release; then
     cat <<'EOF'
 This version of classic was build for Ubuntu Core 16. You appear to be using
 a different version of Ubuntu Core. You can install different versions of

--- a/bin/create
+++ b/bin/create
@@ -5,12 +5,22 @@ set -eu
 ROOT=$SNAP_COMMON/classic
 
 if [ -d $ROOT ]; then
-    echo "classic already enabled"
+    echo "classic already enabled, use classic.reset to remove it again"
     exit 1
 fi
 
 if [ $(id -u) -ne 0 ]; then
     echo "This script needs to be called as root" >&2
+    exit 1
+fi
+
+# FIXME: We really should ensure this also works on
+#        classic, its an easy way to get a chroot there.
+#
+#        However as it is written currently it will break
+#        on classic so disable explicitly to avoid confusion.
+if ! grep -q 'ID=ubuntu-core' /etc/os-release; then
+    echo "Classic mode only works on Ubuntu Core"
     exit 1
 fi
 
@@ -65,3 +75,16 @@ chmod 755 "$ROOT/usr/sbin/policy-rc.d"
 
 # workaround bug in livecd-rootfs
 chmod 1777 "$ROOT/tmp"
+
+# tell the user if classic does not match the ubuntu core release
+if ! grep -q 'VERSION_ID=\"16\"' /etc/os-release; then
+    cat <<EOF
+This version of classic was build for Ubuntu Core 16. You appear to be using
+a different version of Ubuntu Core. You can install different versions of
+the classic environment, e.g. for Ubuntu Core 18:
+
+    sudo snap install --channel=18 classic
+
+'EOF'
+fi
+

--- a/bin/create
+++ b/bin/create
@@ -14,11 +14,6 @@ if [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
-# FIXME: We really should ensure this also works on
-#        classic, its an easy way to get a chroot there.
-#
-#        However as it is written currently it will break
-#        on classic so disable explicitly to avoid confusion.
 if ! grep -q 'ID=ubuntu-core' /etc/os-release; then
     echo "Classic mode only works on Ubuntu Core"
     exit 1
@@ -44,13 +39,27 @@ mkdir $ROOT/snappy
 # call the enable.sh script and make sure we have
 # DNS resolution available (needed by apt update)
 mkdir -p $ROOT/run/resolvconf
-cp /run/resolvconf/resolv.conf $ROOT/run/resolvconf/
+mv $ROOT/etc/resolv.conf $ROOT/etc/resolv.conf.save
+cp /etc/resolv.conf $ROOT/etc
+# make apt work inside the chroot in UC18
+cat > $ROOT/etc/apt/apt.conf.d/00-no-pr-set-new-privs.conf <<EOF
+// "snap run" will apply a seccomp sandbox in "complain" mode.
+// Then apt will call "prctl(PR_SET_NO_NEW_PRIVS)" in the methods
+// which will result in execve() for apt-key to fail. Workaround
+// by disabling the sandbox in apt.
+Debug::NoDropPrivs "1";
+EOF
+# now call enable from inside the core
 sudo chroot $ROOT /var/lib/classic/enable.sh
-rm -rf $ROOT/run/resolvconf
+mv $ROOT/etc/resolv.conf.save $ROOT/etc/resolv.conf
 
 # copy important config
 for f in hostname timezone localtime; do
-    cp -a /etc/writable/$f $ROOT/etc/writable
+    if [ -e /etc/writable/$f ]; then
+        cp -a /etc/writable/$f $ROOT/etc/writable
+    elif [ -e /etc/$f ]; then
+        cp -a /etc/$f $ROOT/writable/etc
+    fi
 done
 for f in hosts; do
     cp -a /etc/$f $ROOT/etc/
@@ -77,14 +86,14 @@ chmod 755 "$ROOT/usr/sbin/policy-rc.d"
 chmod 1777 "$ROOT/tmp"
 
 # tell the user if classic does not match the ubuntu core release
-if ! grep -q 'VERSION_ID=\"16\"' /etc/os-release; then
-    cat <<EOF
+if ! grep -q 'VERSION_ID=\"16\"' /var/lib/snapd/hostfs/etc/os-release; then
+    cat <<'EOF'
 This version of classic was build for Ubuntu Core 16. You appear to be using
 a different version of Ubuntu Core. You can install different versions of
 the classic environment, e.g. for Ubuntu Core 18:
 
     sudo snap install --channel=18 classic
 
-'EOF'
+EOF
 fi
 


### PR DESCRIPTION
This PR will provide more information to the user when creating the
classic environment:
- fail gracefully when trying to run on classic distro
- explain how to remove the environment again when it is already
  enabled
- when the classic version does not match the Ubuntu Core release
  inform the user about this