### PR TITLE
create,classic: make the classic snap work on classic distributions (for 18)

### DIFF
--- a/bin/classic
+++ b/bin/classic
@@ -51,6 +51,12 @@ fi
 # fix LP: #1619455
 cp -a /var/lib/extrausers/* $ROOT/var/lib/extrausers/
 cp -a /etc/sudoers.d/* $ROOT/etc/sudoers.d/
+# this is only needed when this is run on classic
+if ! grep -q ^${SUDO_USER} $ROOT/var/lib/extrausers/passwd && ! grep -q ^${SUDO_USER} $ROOT/etc/passwd; then
+    grep ^${SUDO_USER} /etc/passwd >> $ROOT/etc/passwd
+    grep ^${SUDO_USER} /etc/shadow >> $ROOT/etc/shadow
+    echo "${SUDO_USER} ALL=(ALL) NOPASSWD:ALL" > $ROOT/etc/sudoers.d/${SUDO_USER}
+fi
 
 # assemble command line
 DEVPTS="mount -o mode=666,ptmxmode=666 -t devpts devpts /dev/pts"

--- a/bin/create
+++ b/bin/create
@@ -40,7 +40,7 @@ chroot $ROOT apt install -y sudo libnss-extrausers vim.tiny
 
 # copy important config
 for f in hostname timezone localtime; do
-    cp -a /etc/writable/$f $ROOT/etc
+    cp -aL /etc/$f $ROOT/etc
 done
 for f in resolv.conf nsswitch.conf hosts; do
     cp -a /etc/$f $ROOT/etc


### PR DESCRIPTION
So far the classic snap was crashing in create because it made
assumptions about how /etc looks like and that users are managed
via extrausers.

This PR fixes this so that the classic snap will work on at least
regular Ubuntu releases. It's not *super* useful there but it may
be a convinient way to get a chroot with the right bind mounts
etc. To make it work the "classic" command will ensure the
SUDO_USER is available in the chroot and has sudo access in there.

Alternatively we could simply refuse to run in "classic.create"
if this is run on a non Ubuntu Core device.