### PR TITLE
Add simple spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -26,3 +26,6 @@ suites:
       snapcraft
       echo "Install snap"
       snap install --dangerous --devmode classic_*.snap
+    restore: |
+      echo "Ensure snapd and all snaps are gone"
+      apt autoremove -y --purge snapd snapcraft

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,28 @@
+project: classic-snap
+
+path: /home/spread
+
+backends:
+  qemu:
+    systems:
+      - ubuntu-16.04-64:
+          username: ubuntu
+          password: ubuntu
+      - ubuntu-18.04-64:
+          username: ubuntu
+          password: ubuntu
+
+suites:
+  tests/main/:
+    summary: Integration test for the classic snap
+    prepare: |
+      echo "Prepare image"
+      apt update
+      apt install -y snapd snapcraft
+      snap install core
+      echo "Build snap"
+      cd $SPREAD_PATH
+      snapcraft clean
+      snapcraft
+      echo "Install snap"
+      snap install --dangerous --devmode classic_*.snap

--- a/tests/main/basic/task.yaml
+++ b/tests/main/basic/task.yaml
@@ -1,5 +1,9 @@
 summary: Check that the classic snap works
 
+restore: |
+    echo "Ensure cleanup even if the test fails"
+    classic.reset || true
+
 execute: |
     echo "Ensure create works"
     classic.create

--- a/tests/main/basic/task.yaml
+++ b/tests/main/basic/task.yaml
@@ -1,6 +1,26 @@
 summary: Check that the classic snap works
 
 execute: |
+    echo "Ensure create works"
     classic.create
-    classic cat /etc/os-release | MATCH '^ID=ubuntu'
+    if classic cat /etc/os-release | grep -E "ID=ubuntu-core"; then
+        echo "classic environment has unexpected ID=ubuntu-core"
+        exit 1
+    fi
+
+    echo "Ensure installing of stuff works"
+    classic apt update
+    classic apt install -y mc
+    [ -x /var/snap/classic/common/classic/usr/bin/mc ]
+
+    echo "Ensure daemons are not started"
+    [ -x /var/snap/classic/common/classic/usr/sbin/policy-rc.d ]
+    classic apt install -y apache2
+    if echo "GET / HTTP/1.0\n\n" | nc localhost 80; then
+        echo "apache is now listening on localhost - this should not happen"
+        exit 1
+    fi
+    
+    echo "Ensure reset works"
     classic.reset
+    [ ! -d /var/snap/classic/common/classic ]

--- a/tests/main/basic/task.yaml
+++ b/tests/main/basic/task.yaml
@@ -1,0 +1,6 @@
+summary: Check that the classic snap works
+
+execute: |
+    classic.create
+    classic cat /etc/os-release | MATCH '^ID=ubuntu'
+    classic.reset


### PR DESCRIPTION
This adds simple tests for the classic snap. For now inside qemu
and traditional ubuntu. Then we can port it to run in google
automatically and eventually also add ubuntu core.