### PR TITLE
enable spread tests for core as well (18)

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -40,7 +40,9 @@ chroot $ROOT apt install -y sudo libnss-extrausers vim.tiny
 
 # copy important config
 for f in hostname timezone localtime; do
-    cp -aL /etc/$f $ROOT/etc
+    if [ -e /etc/$f ]; then
+        cp -aL /etc/$f $ROOT/etc
+    fi
 done
 for f in resolv.conf nsswitch.conf hosts; do
     cp -a /etc/$f $ROOT/etc

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,21 +11,40 @@ backends:
       - ubuntu-18.04-64:
           username: ubuntu
           password: ubuntu
+      # create this image from
+      # http://cdimage.ubuntu.com/ubuntu-core/16/stable/current/ubuntu-core-16-amd64.img.xz
+      # Boot with: "kvm -m 1500 -redir tcp:10022::22 ubuntu-core-16-64-amd64.img"
+      # create ssh user, login via ssh and then:
+      # $ sudo adduser --extrausers ubuntu
+      # $ echo "ubuntu ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/ubuntu
+      # $ sync
+      - ubuntu-core-16-64:
+          username: ubuntu
+          password: ubuntu
+      - ubuntu-core-18-64:
+          username: ubuntu
+          password: ubuntu
 
 suites:
   tests/main/:
     summary: Integration test for the classic snap
     prepare: |
-      echo "Prepare image"
-      apt update
-      apt install -y snapd snapcraft
-      snap install core
-      echo "Build snap"
-      cd $SPREAD_PATH
-      snapcraft clean
-      snapcraft
+      # FIXME: classic does not pass environment so workaround here
+      echo $SPREAD_PATH > /run/SPREAD_PATH
+      if [ ! -f /var/lib/dpkg/status ]; then
+          # ubuntu-core (we need classic first to build classic)
+          when="$(date --iso-8601=seconds -d 'tomorrow 8:05 UTC')"
+          snap set core refresh.hold="$when"
+          snap install classic --devmode --edge
+          classic $SPREAD_PATH/tests/lib/build.sh
+          snap remove classic
+      else
+          $SPREAD_PATH/tests/lib/build.sh
+      fi
       echo "Install snap"
-      snap install --dangerous --devmode classic_*.snap
+      snap install --dangerous --devmode $SPREAD_PATH/classic_*.snap
     restore: |
       echo "Ensure snapd and all snaps are gone"
-      apt autoremove -y --purge snapd snapcraft
+      if [ -f /var/lib/dpkg/status ]; then
+          apt autoremove -y --purge snapd snapcraft
+      fi

--- a/tests/lib/build.sh
+++ b/tests/lib/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+apt update
+apt install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y snapd snapcraft
+snap install core
+echo "Build snap"
+# FIXME: classic does not pass environment, so work around here
+cd $(cat /run/SPREAD_PATH)
+snapcraft clean
+snapcraft


### PR DESCRIPTION
This allows to run the tests for the classic classic snap on ubuntu core.