### PR TITLE
create: only copy config that exists

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -50,7 +50,9 @@ mv $ROOT/etc/resolv.conf.save $ROOT/etc/resolv.conf
 
 # copy important config
 for f in hostname timezone localtime hosts resolv.conf; do
-    cp -aL --remove-destination /etc/$f $ROOT/etc
+    if [ -e /etc/$f ]; then
+        cp -aL --remove-destination /etc/$f $ROOT/etc
+    fi
 done
 
 # create /etc/alternatives for now


### PR DESCRIPTION
Trivial fix: core18 does not have all the config files.